### PR TITLE
feat: Builder: Add builder and readme about usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# HogWarp Chat
+
+## Usage
+
+### Builder
+
+The following codeblock describes the usage of the `ChatMessage Builder` that allows for different styles inside the same message and some more details.
+
+```cs
+var builder = new ChatMessage.Builder();
+builder.AddIcon(ChatIcon.Gryffindor);
+builder.AddText("Default ", ChatTextStyle.Default);
+builder.AddText("Gryffindor ", ChatTextStyle.Gryffindor);
+builder.AddText("Hufflepuff ", ChatTextStyle.Hufflepuff);
+builder.AddText("Ravenclaw ", ChatTextStyle.Ravenclaw);
+builder.AddText("Slytherin ", ChatTextStyle.Slytherin);
+builder.AddText("Admin ", ChatTextStyle.Admin);
+builder.AddText("Dev ", ChatTextStyle.Dev);
+builder.AddText("Server ", ChatTextStyle.Server);
+builder.AddText("Red ", ChatTextStyle.Red);
+builder.AddText("Blue ", ChatTextStyle.Blue);
+builder.AddText("Green ", ChatTextStyle.Green);
+builder.AddText("Yellow ", ChatTextStyle.Yellow);
+builder.AddText("Magenta ", ChatTextStyle.Magenta);
+builder.AddText("Cyan ", ChatTextStyle.Cyan);
+builder.AddSender(player.Username, ChatTextStyle.Server);
+SendMessage(player, builder.Build().Message);
+```
+

--- a/Server/ChatIcon.cs
+++ b/Server/ChatIcon.cs
@@ -1,0 +1,12 @@
+﻿namespace HogWarpChat;
+
+/// <summary>
+/// The following icons are added in front of the sender
+/// </summary>
+public enum ChatIcon
+{
+	Gryffindor,
+	Hufflepuff,
+	Ravenclaw,
+	Slytherin
+}

--- a/Server/ChatMessage.cs
+++ b/Server/ChatMessage.cs
@@ -1,0 +1,111 @@
+﻿namespace HogWarpChat;
+
+public sealed class ChatMessage
+{
+	private bool _includeTimestamp;
+	private ChatIcon? _icon;
+	private string _sender = string.Empty;
+	private string _texts = string.Empty;
+	
+	/// <summary>
+	/// Contains the completely builded chat message
+	/// </summary>
+	public string Message { get; private set; } = string.Empty;
+	
+	public sealed class Builder(bool includeTimestamp = true)
+	{
+		private readonly ChatMessage _chatMessage = new() { _includeTimestamp = includeTimestamp };
+
+		/// <summary>
+		/// Prepends the chat message with an icon
+		/// </summary>
+		public Builder AddIcon(ChatIcon icon)
+		{
+			_chatMessage._icon = icon;
+			return this;
+		}
+		
+		#region SENDER
+		
+		/// <summary>
+		/// Adds a sender to the chat message with default style
+		/// </summary>
+		public Builder AddSender(string sender)
+		{
+			_chatMessage._sender = $"{sender}:";
+			return this;
+		}
+		
+		/// <summary>
+		/// Adds a sender to the chat message 
+		/// </summary>
+		public Builder AddSender(string sender, ChatStyle style)
+		{
+			if (style.Style == ChatTextStyle.Default)
+				return AddSender(sender);
+			_chatMessage._sender += $"<{style.Value}>{sender}:</>";
+			return this;
+		}
+		
+		/// <summary>
+		/// Adds a sender to the chat message with the given style
+		/// </summary>
+		public Builder AddSender(string sender, ChatTextStyle style)
+		{
+			return ChatStyles.Styles.TryGetValue(style, out var textStyle) 
+				? AddSender(sender, textStyle) 
+				: AddSender(sender);
+		}
+		
+		#endregion
+
+		#region TEXTS
+	
+		/// <summary>
+		/// Adds a default text to the message
+		/// </summary>
+		public Builder AddText(string text)
+		{
+			_chatMessage._texts += text;
+			return this;
+		}
+		
+		/// <summary>
+		/// Adds a text to the chat message with the given style
+		/// </summary>
+		public Builder AddText(string text, ChatStyle style)
+		{
+			if (style.Style == ChatTextStyle.Default)
+				return AddText(text);
+			_chatMessage._texts += $"<{style.Value}>{text}</>";
+			return this;
+		}
+		
+		/// <summary>
+		/// Adds a text to the chat message with the given style
+		/// </summary>
+		public Builder AddText(string text, ChatTextStyle style)
+		{
+			return ChatStyles.Styles.TryGetValue(style, out var textStyle) 
+				? AddText(text, textStyle) 
+				: AddText(text);
+		}
+
+		/// <summary>
+		/// Builds the chat message based on the available icon, sender and texts.
+		/// </summary>
+		public ChatMessage Build()
+		{
+			if (_chatMessage._includeTimestamp)
+				_chatMessage.Message += DateTime.Now.ToString("[HH:mm] ");
+			if (_chatMessage._icon is not null)
+				_chatMessage.Message += $"<img id=\"{_chatMessage._icon}\"></> ";
+			if (!string.IsNullOrEmpty(_chatMessage._sender))
+				_chatMessage.Message += $"{_chatMessage._sender} "; // Just for the whitespace
+			_chatMessage.Message += _chatMessage._texts;
+			return _chatMessage;
+		}
+		
+		#endregion
+	}
+}

--- a/Server/ChatTextStyle.cs
+++ b/Server/ChatTextStyle.cs
@@ -1,0 +1,61 @@
+﻿namespace HogWarpChat;
+
+public enum ChatTextStyle
+{
+	Default,
+	Gryffindor,
+	Hufflepuff,
+	Ravenclaw,
+	Slytherin,
+	Admin,
+	Dev,
+	Server,
+	Red,
+	Blue,
+	Green,
+	Yellow,
+	Magenta,
+	Cyan
+}
+
+public sealed class ChatStyle(ChatTextStyle style, string value)
+{
+	public readonly ChatTextStyle Style = style;
+	public readonly string Value = value;
+}
+
+public static class ChatStyles
+{
+	public static readonly ChatStyle Default = new (ChatTextStyle.Default, "Default");
+	public static readonly ChatStyle Gryffindor = new (ChatTextStyle.Gryffindor, "Gryffindor");
+	public static readonly ChatStyle Hufflepuff = new (ChatTextStyle.Hufflepuff, "Hufflepuff");
+	public static readonly ChatStyle Ravenclaw = new (ChatTextStyle.Ravenclaw, "Ravenclaw");
+	public static readonly ChatStyle Slytherin = new (ChatTextStyle.Slytherin, "Slytherin");
+	public static readonly ChatStyle Admin = new (ChatTextStyle.Admin, "Admin");
+	public static readonly ChatStyle Dev = new (ChatTextStyle.Dev, "Dev");
+	public static readonly ChatStyle Server = new (ChatTextStyle.Server, "Server");
+	public static readonly ChatStyle Red = new (ChatTextStyle.Red, "FF0000FF");
+	public static readonly ChatStyle Blue = new (ChatTextStyle.Blue, "0000FFFF");
+	public static readonly ChatStyle Green = new (ChatTextStyle.Green, "00FF00FF");
+	public static readonly ChatStyle Yellow = new (ChatTextStyle.Yellow, "FFFF00FF");
+	public static readonly ChatStyle Magenta = new (ChatTextStyle.Magenta, "FF00FFFF");
+	public static readonly ChatStyle Cyan = new (ChatTextStyle.Cyan, "00FFFFFF");
+
+	public static Dictionary<ChatTextStyle, ChatStyle> Styles = new()
+	{
+		{ ChatTextStyle.Default, Default },
+		{ ChatTextStyle.Gryffindor, Gryffindor },
+		{ ChatTextStyle.Hufflepuff, Hufflepuff },
+		{ ChatTextStyle.Ravenclaw, Ravenclaw },
+		{ ChatTextStyle.Slytherin, Slytherin },
+		{ ChatTextStyle.Admin, Admin },
+		{ ChatTextStyle.Dev, Dev },
+		{ ChatTextStyle.Server, Server },
+		{ ChatTextStyle.Red, Red },
+		{ ChatTextStyle.Blue, Blue },
+		{ ChatTextStyle.Green, Green },
+		{ ChatTextStyle.Yellow, Yellow },
+		{ ChatTextStyle.Magenta, Magenta },
+		{ ChatTextStyle.Cyan, Cyan },
+	};
+}


### PR DESCRIPTION
This branch adds a `ChatMessage Builder` that allows for easier construction of multi-style text messages, as shown here:


![example](https://github.com/user-attachments/assets/e899e02e-d6b7-489c-b603-d40b313d119e)

The usage is described in the `README.md`
